### PR TITLE
Iss5 - Fixes compilation on Ubuntu. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 find_package(LCIO REQUIRED)
 
 # find Python installation
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs 2.7 REQUIRED)
 message(STATUS "Python lib found at: ${PYTHON_LIBRARIES}")
 message(STATUS "Python include dir found at: ${PYTHON_INCLUDE_DIRS}")
 get_filename_component(PYTHON_LIBRARY_DIR ${PYTHON_LIBRARIES} DIRECTORY)

--- a/cmake/Modules/MacroModule.cmake
+++ b/cmake/Modules/MacroModule.cmake
@@ -108,7 +108,7 @@ macro(MODULE)
   
   # make list of libraries required by executables and test programs which includes this module's lib
   if (sources)
-    set(MODULE_BIN_LIBRARIES ${MODULE_LIBRARIES} ${MODULE_NAME})
+    set(MODULE_BIN_LIBRARIES ${MODULE_NAME} ${MODULE_LIBRARIES})
   else()
     set(MODULE_BIN_LIBRARIES ${MODULE_LIBRARIES})
   endif()


### PR DESCRIPTION
On OpenSuse, the order in which the libraries are linked doesn't matter.  However, on Ubuntu, compilation succeeds only if module specific libraries are first in the link list.  This was fixed by changing the ordering in MacroModule.cmake. 

The fix was tested on both OpenSuse Leap 15 and Ubuntu 18.04. 